### PR TITLE
added attach option for transient window

### DIFF
--- a/src/about.c
+++ b/src/about.c
@@ -308,7 +308,7 @@ zenity_about (ZenityData *data)
                     G_CALLBACK (zenity_zen_wisdom), NULL);
 #endif
 
-  zenity_util_show_dialog (dialog);
+  zenity_util_show_dialog (dialog, data->attach);
   gtk_main ();
 }
 

--- a/src/calendar.c
+++ b/src/calendar.c
@@ -86,7 +86,7 @@ zenity_calendar (ZenityData *data, ZenityCalendarData *cal_data)
 		    G_CALLBACK (zenity_calendar_double_click), data);
 
   gtk_label_set_mnemonic_widget (GTK_LABEL (text), calendar);
-  zenity_util_show_dialog (dialog);
+  zenity_util_show_dialog (dialog, data->attach);
 
   if (data->timeout_delay > 0) {
     g_timeout_add_seconds (data->timeout_delay, (GSourceFunc) zenity_util_timeout_handle, dialog);

--- a/src/color.c
+++ b/src/color.c
@@ -79,7 +79,7 @@ void zenity_colorselection (ZenityData *data, ZenityColorData *color_data)
   gtk_color_selection_set_has_palette (GTK_COLOR_SELECTION (colorsel),
                                        color_data->show_palette);
 
-  zenity_util_show_dialog (dialog);
+  zenity_util_show_dialog (dialog, data->attach);
 
   if (data->timeout_delay > 0) {
     g_timeout_add (data->timeout_delay * 1000,

--- a/src/entry.c
+++ b/src/entry.c
@@ -144,7 +144,7 @@ zenity_entry (ZenityData *data, ZenityEntryData *entry_data)
 
   g_object_unref (builder);
 
-  zenity_util_show_dialog (dialog);
+  zenity_util_show_dialog (dialog, data->attach);
 
   if(data->timeout_delay > 0) {
     g_timeout_add_seconds (data->timeout_delay, (GSourceFunc) zenity_util_timeout_handle, dialog);

--- a/src/fileselection.c
+++ b/src/fileselection.c
@@ -136,7 +136,7 @@ void zenity_fileselection (ZenityData *data, ZenityFileData *file_data)
     }
   }
 
-  zenity_util_show_dialog (dialog);
+  zenity_util_show_dialog (dialog, data->attach);
 
   if(data->timeout_delay > 0) {
     g_timeout_add_seconds (data->timeout_delay, (GSourceFunc) zenity_util_timeout_handle, dialog);

--- a/src/msg.c
+++ b/src/msg.c
@@ -165,7 +165,7 @@ zenity_msg (ZenityData *data, ZenityMsgData *msg_data)
   if (msg_data->no_wrap)
     gtk_label_set_line_wrap (GTK_LABEL (text), FALSE);
 
-  zenity_util_show_dialog (dialog);
+  zenity_util_show_dialog (dialog, data->attach);
 
   if(data->timeout_delay > 0) {
     g_timeout_add_seconds (data->timeout_delay, (GSourceFunc) zenity_util_timeout_handle, NULL);

--- a/src/option.c
+++ b/src/option.c
@@ -46,6 +46,7 @@ static gint     zenity_general_timeout_delay;
 static gchar   *zenity_general_ok_button;
 static gchar   *zenity_general_cancel_button;
 static gboolean zenity_general_modal;
+static gint     zenity_general_attach;
 
 /* Calendar Dialog Options */
 static gboolean zenity_calendar_active;
@@ -221,6 +222,15 @@ static GOptionEntry general_options[] = {
     &zenity_general_modal,
     N_("Set the modal hint"),
     NULL
+  },
+  {
+    "attach",
+    '\0',
+    G_OPTION_FLAG_NOALIAS,
+    G_OPTION_ARG_INT,
+    &zenity_general_attach,
+    N_("Set the parent window to attach to"),
+    N_("WINDOW")
   },
   {
     NULL
@@ -1350,6 +1360,7 @@ zenity_general_pre_callback (GOptionContext *context,
   zenity_general_dialog_no_markup = FALSE;
   zenity_general_timeout_delay = -1;
   zenity_general_modal = FALSE;
+  zenity_general_attach = 0;
 
   return TRUE;
 }
@@ -1588,6 +1599,7 @@ zenity_general_post_callback (GOptionContext *context,
   results->data->ok_label = zenity_general_ok_button;
   results->data->cancel_label = zenity_general_cancel_button;
   results->data->modal = zenity_general_modal;
+  results->data->attach = zenity_general_attach;
   return TRUE;
 }
 

--- a/src/password.c
+++ b/src/password.c
@@ -141,7 +141,7 @@ void zenity_password_dialog (ZenityData *data, ZenityPasswordData *password_data
                     G_CALLBACK (zenity_password_dialog_response),
                     password_data);
   gtk_widget_show_all(GTK_WIDGET(gtk_dialog_get_content_area(GTK_DIALOG(dialog))));
-  zenity_util_show_dialog (dialog);
+  zenity_util_show_dialog (dialog, data->attach);
 
   if (data->timeout_delay > 0) {
     g_timeout_add (data->timeout_delay * 1000,

--- a/src/progress.c
+++ b/src/progress.c
@@ -302,7 +302,7 @@ zenity_progress (ZenityData *data, ZenityProgressData *progress_data)
   if (no_cancel && auto_close)
      gtk_widget_hide(GTK_WIDGET(ok_button));
 
-  zenity_util_show_dialog (dialog);
+  zenity_util_show_dialog (dialog, data->attach);
   zenity_progress_read_info (progress_data);
 
   if(data->timeout_delay > 0) {

--- a/src/scale.c
+++ b/src/scale.c
@@ -107,7 +107,7 @@ zenity_scale (ZenityData *data, ZenityScaleData *scale_data)
   if (scale_data->hide_value)
     gtk_scale_set_draw_value (GTK_SCALE (scale), FALSE);
   
-  zenity_util_show_dialog (dialog);
+  zenity_util_show_dialog (dialog, data->attach);
 
   if(data->timeout_delay > 0) {
     g_timeout_add_seconds (data->timeout_delay, (GSourceFunc) zenity_util_timeout_handle, dialog);

--- a/src/text.c
+++ b/src/text.c
@@ -326,7 +326,7 @@ zenity_text (ZenityData *data, ZenityTextData *text_data)
     gtk_widget_show (GTK_WIDGET (web_kit));
   }
 #endif
-  zenity_util_show_dialog (dialog);
+  zenity_util_show_dialog (dialog, data->attach);
 
   g_object_unref (builder);
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -562,7 +562,7 @@ zenity_tree (ZenityData *data, ZenityTreeData *tree_data)
       zenity_tree_fill_entries_from_stdin (GTK_TREE_VIEW (tree_view), n_columns, FALSE, tree_data->editable);
   }
 
-  zenity_util_show_dialog (dialog);
+  zenity_util_show_dialog (dialog, data->attach);
 
   if(data->timeout_delay > 0) {
     g_timeout_add_seconds (data->timeout_delay, (GSourceFunc) zenity_util_timeout_handle, dialog);

--- a/src/util.h
+++ b/src/util.h
@@ -4,6 +4,10 @@
 #include <gtk/gtk.h>
 #include "zenity.h"
 
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
 G_BEGIN_DECLS
 
 #define ZENITY_UI_FILE_FULLPATH              ZENITY_DATADIR "/zenity.ui"
@@ -28,7 +32,7 @@ void		zenity_util_show_help                     (GError        **error);
 gint		zenity_util_return_exit_code 		  (ZenityExitCode value);                      
 void            zenity_util_exit_code_with_data           (ZenityExitCode value,
                                                            ZenityData     *data);
-void            zenity_util_show_dialog                   (GtkWidget      *widget);
+void            zenity_util_show_dialog                   (GtkWidget      *widget, Window parent);
 
 gboolean        zenity_util_timeout_handle                (gpointer data);
 

--- a/src/zenity.h
+++ b/src/zenity.h
@@ -33,6 +33,7 @@ typedef struct {
   gint   exit_code;
   gint   timeout_delay;
   gboolean modal;
+  gint   attach;
 } ZenityData;
 
 typedef enum {


### PR DESCRIPTION
I made a little changed to zenity which added a new option, --attach.
With this option, user can set which window transient for, its very useful
when user call zenity from his/her own app rather than terminal.
