### PR TITLE
Fixed an apparent Typo, which caused a crash if this sort of command …

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -1825,7 +1825,7 @@ zenity_forms_post_callback (GOptionContext *context, GOptionGroup *group,
 			while (values != NULL) {
 				results->forms_data->column_values =
 					g_slist_append (results->forms_data->column_values, values);
-				values = zenity_forms_list_values[++i];
+				values = zenity_forms_column_values[++i];
 			}
 		} else
 			results->forms_data->column_values =


### PR DESCRIPTION
…is entered:

src/zenity --forms --title 'Enter Dest Host' --add-entry='Dest HostName or IP' --add-entry='Dest Port' --column-values=' |22'

I still can't put "default" text in a text entry box, but, at least, I don't crash any more.

murf