### PR TITLE
Support pango markup in entry dialog

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -111,8 +111,12 @@ zenity_entry (ZenityData *data, ZenityEntryData *entry_data) {
 	text = gtk_builder_get_object (builder, "zenity_entry_text");
 
 	if (entry_data->dialog_text)
-		gtk_label_set_text_with_mnemonic (
-			GTK_LABEL (text), g_strcompress (entry_data->dialog_text));
+		if (entry_data->no_markup)
+			gtk_label_set_text_with_mnemonic (
+				GTK_LABEL (text), g_strcompress (entry_data->dialog_text));
+		else
+			gtk_label_set_markup_with_mnemonic (
+				GTK_LABEL (text), g_strcompress (entry_data->dialog_text));
 
 	vbox = gtk_builder_get_object (builder, "vbox4");
 

--- a/src/option.c
+++ b/src/option.c
@@ -301,6 +301,12 @@ static GOptionEntry entry_options[] = {{"entry",
 		&zenity_entry_hide_text,
 		N_ ("Hide the entry text"),
 		NULL},
+	{"no-markup",
+		'\0',
+		G_OPTION_FLAG_NOALIAS,
+		G_OPTION_ARG_NONE,
+		&zenity_general_dialog_no_markup,
+		N_ ("Do not enable Pango markup")},
 	{NULL}};
 
 static GOptionEntry error_options[] = {{"error",
@@ -1455,6 +1461,7 @@ zenity_entry_post_callback (GOptionContext *context, GOptionGroup *group,
 		results->entry_data->dialog_text = zenity_general_dialog_text;
 		results->entry_data->entry_text = zenity_entry_entry_text;
 		results->entry_data->hide_text = zenity_entry_hide_text;
+		results->entry_data->no_markup = zenity_general_dialog_no_markup;
 	} else {
 		if (zenity_entry_entry_text)
 			zenity_option_error (zenity_option_get_name (

--- a/src/zenity.h
+++ b/src/zenity.h
@@ -96,6 +96,7 @@ typedef struct {
 	gchar *dialog_text;
 	gchar *entry_text;
 	gboolean hide_text;
+	gboolean no_markup;
 	const gchar **data;
 } ZenityEntryData;
 


### PR DESCRIPTION
This commit makes it possible to use pango markup in the entry dialog.
In fact, it makes it the default, just like for the various message dialogs.