### PR TITLE
Keep icon in info dialog in the top left when resizing

### DIFF
--- a/src/zenity.ui
+++ b/src/zenity.ui
@@ -725,6 +725,8 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="yalign">0</property>
+                <property name="halign">start</property>
+                <property name="valign">start</property>
                 <property name="icon_name">dialog-information</property>
                 <property name="icon_size">6</property>
               </object>


### PR DESCRIPTION
This makes the text and icon not move around when the window is resized. I feel like this window could be made to deal with resizing even better, but this fixes my main gripe with it.