### PR TITLE
Added icon-name property to man page

### DIFF
--- a/data/zenity.1
+++ b/data/zenity.1
@@ -79,6 +79,9 @@ Set the dialog title
 .B \-\-window-icon=ICONPATH
 Set the window icon with the path to an image. Alternatively, one of the four stock icons can be used: 'error', 'info', 'question' or 'warning'
 .TP
+.B \-\-icon-name=ICONNAME
+The name of the icon to display on the dialog to override the default stock icons
+.TP
 .B \-\-width=WIDTH
 Set the dialog width
 .TP


### PR DESCRIPTION
I recently came across the "icon-name" property to override the stock icons on the zenity dialog, but this feature is not currently documented in the zenity man page. This PR adds the property to the man page. Thank you